### PR TITLE
Allow base 4.18.0.0

### DIFF
--- a/zigzag.cabal
+++ b/zigzag.cabal
@@ -21,7 +21,7 @@ library
     Data.Word.Zigzag
   -- other-modules:
   build-depends:
-    , base >=4.11.1 && <4.18
+    , base >=4.11.1 && <4.19
   default-language: Haskell2010
   ghc-options: -O2 -Wall -Wunticked-promoted-constructors
 


### PR DESCRIPTION
Update zigzag.cabal to include base 4.18 in bounds in order to support ghc 9.6. Tested locally with `cabal test -w ghc-9.6 --constraint 'base==4.18.0.0'`. Would love if we could have a metadata revision after merging. 